### PR TITLE
Add cursor:zoom-in and cursor:zoom-out property value aliases

### DIFF
--- a/Aliases.ini
+++ b/Aliases.ini
@@ -198,6 +198,18 @@
 
 [values]
 
+    ; Cursor
+    cursor:zoom-in[] = -webkit-zoom-in
+    cursor:zoom-in[] = -moz-zoom-in
+    cursor:zoom-in[] = -ms-zoom-in
+    cursor:zoom-in[] = -o-zoom-in
+    cursor:zoom-in[] = zoom-in
+    cursor:zoom-out[] = -webkit-zoom-out
+    cursor:zoom-out[] = -moz-zoom-out
+    cursor:zoom-out[] = -ms-zoom-out
+    cursor:zoom-out[] = -o-zoom-out
+    cursor:zoom-out[] = zoom-out
+
     ; Flexbox TBC.
 
 


### PR DESCRIPTION
Add cursor:zoom-in and cursor:zoom-out (https://developer.mozilla.org/en-US/docs/CSS/cursor#Browser_compatibility)
