### PR TITLE
corrected typo in docs: core--selector-grouping

### DIFF
--- a/docs/core/selector-aliases.md
+++ b/docs/core/selector-aliases.md
@@ -6,7 +6,7 @@
 
 Selector aliases can be useful for grouping together common selector chains for reuse.
 
-They're  defined with the `@selector` directive, and can be used anywhere you might use a psuedo class.
+They're  defined with the `@selector` directive, and can be used anywhere, you might use a pseudo class.
 
 
 ```crush


### PR DESCRIPTION
I guess it's a type in docs - "psuedo"?
Corrected it.
I'm not native speaker so I'm not sure it wasn't OK.
