### PR TITLE
Allow for @ifset <name>(<value>) checks.

### DIFF
--- a/docs/core/variables.md
+++ b/docs/core/variables.md
@@ -42,6 +42,7 @@ Sections of CSS can be included and excluded on the basis of variable existence 
 
 ```crush
 @set foo #f00;
+@set bar true;
 
 @ifset foo {
   p {
@@ -53,6 +54,9 @@ p {
   font-size: 12px;
   @ifset not foo {
     line-height: 1.5;
+  }
+  @ifset bar(true) {
+    margin-bottom: 5px;
   }
 }
 ```

--- a/lib/CssCrush/Process.php
+++ b/lib/CssCrush/Process.php
@@ -457,7 +457,7 @@ class Process
 
     protected function resolveIfDefines()
     {
-        $ifdefinePatt = Regex::make('~@if(?:set|define) \s+ (?<negate>not \s+)? (?<name>{{ ident }}) \s* \{~ixS');
+        $ifdefinePatt = Regex::make('~@if(?:set|define) \s+ (?<negate>not \s+)? (?<name>{{ ident }}) \s* (?:\( \s* (?<value>[a-zA-Z0-9_-]+) \s* \) \s*)? \s* \{~ixS');
 
         $matches = $this->string->matchAll($ifdefinePatt);
 
@@ -472,7 +472,15 @@ class Process
             $negate = $match['negate'][1] != -1;
             $nameDefined = isset($this->vars[$match['name'][0]]);
 
-            if (! $negate && $nameDefined || $negate && ! $nameDefined) {
+            $valueDefined = isset($match['value'][0]);
+            $valueMatch = $nameDefined && $valueDefined ? $this->vars[$match['name'][0]] == $match['value'][0] : false;
+
+            if(
+                ( $valueDefined && !$negate && $valueMatch )
+                || ( $valueDefined && $negate && !$valueMatch )
+                || ( !$valueDefined && !$negate && $nameDefined )
+                || ( !$valueDefined && $negate && !$nameDefined )
+            ) {
                 $curlyMatch->unWrap();
             }
             else {


### PR DESCRIPTION
This will fix issue #73 and help @unetics with #70.

```crush
@set bar true;

@ifset bar(true) {
  p {
    margin-bottom: 5px;
  }
}
```

This will work alongside the original @ifset, aswell as the optional @ifset not.