### PR TITLE
New Feature to loop : $(#(var))

### DIFF
--- a/lib/CssCrush/Process.php
+++ b/lib/CssCrush/Process.php
@@ -821,7 +821,9 @@ class Process
                     }
                     // If output dir is different to input dir prepend a link between the two.
                     elseif ($link) {
-                        $url->prepend($link);
+                        // If rewrite_import_urls is active
+                        if($options->rewrite_import_urls === true)
+                            $url->prepend($link);
                     }
                 }
             }

--- a/lib/CssCrush/Process.php
+++ b/lib/CssCrush/Process.php
@@ -887,6 +887,9 @@ class Process
         $importer = new Importer($this);
         $this->string = new StringObject($importer->collate());
 
+        // Capture phase 0 hook: Before all variables and settings have resolved.
+        $this->hooks->run('capture_phase0', $this);
+        
         $this->captureVars();
 
         $this->placeAllVars();

--- a/plugins/loop.php
+++ b/plugins/loop.php
@@ -8,7 +8,7 @@ namespace CssCrush;
 
 Plugin::register('loop', array(
     'enable' => function ($process) {
-        $process->hooks->add('capture_phase1', 'CssCrush\loop');
+        $process->hooks->add('capture_phase0', 'CssCrush\loop');
     }
 ));
 


### PR DESCRIPTION
The changes below enable $(#(var)) in loop plugin.

Example :
@set {
    Red: #ff0000;
    Green: #00ff00;
    Blue : #0000ff;
}
@for Color in Red, Green, Blue {
    .#(Color) {
        color:$(#(Color));
    }
}

The result is : 
.Red { color:#ff0000; }
.Green { color:#00ff00; }
.Blue { color:#0000ff; }

Another change, just a new condition before replace rewrite import urls in Process.