### PR TITLE
Fix of php warning: Set memory_limit only if the current value is smaller

### DIFF
--- a/lib/CssCrush/Process.php
+++ b/lib/CssCrush/Process.php
@@ -913,6 +913,9 @@ class Process
             'memory_limit' => '128M',
         ] as $name => $value) {
             $this->iniOriginal[$name] = ini_get($name);
+            if ($name === 'memory_limit' && intval(ini_get($name)) > intval($value)) {
+                continue;
+            }
             ini_set($name, $value);
         }
 

--- a/lib/CssCrush/Process.php
+++ b/lib/CssCrush/Process.php
@@ -913,7 +913,7 @@ class Process
             'memory_limit' => '128M',
         ] as $name => $value) {
             $this->iniOriginal[$name] = ini_get($name);
-            if ($name === 'memory_limit' && intval(ini_get($name)) > intval($value)) {
+            if ($name === 'memory_limit' && $this->returnBytes(ini_get($name)) > $this->returnBytes($value)) {
                 continue;
             }
             ini_set($name, $value);
@@ -925,6 +925,23 @@ class Process
         $this->functions->setPattern(true);
 
         $this->stat['compile_start_time'] = microtime(true);
+    }
+    
+    private function returnBytes(string $value)
+    {
+        $value = trim($value);
+        $last = strtolower($value[strlen($value) - 1]);
+        switch ($last) {
+            // The 'G' modifier is available
+            case 'g':
+                $value *= 1024;
+            case 'm':
+                $value *= 1024;
+            case 'k':
+                $value *= 1024;
+        }
+
+        return $value;
     }
 
     public function postCompile()


### PR DESCRIPTION
![image (1)](https://user-images.githubusercontent.com/40769979/131481319-9f44dade-ff6a-4ff5-9333-82380c9e52ca.png)
